### PR TITLE
LoadError in macOS

### DIFF
--- a/lib/mphash.rb
+++ b/lib/mphash.rb
@@ -25,7 +25,11 @@
 # OF SUCH DAMAGE.
 
 require 'mphash/missing'
-require 'mphash.so'
+begin
+  require 'mphash.so'
+rescue LoadError
+  require 'mphash.bundle'
+end
 require 'mphash/mphf'
 require 'mphash/escape'
 


### PR DESCRIPTION
In macOS, generated object file is "mphash.bundle", not "mphash.so".