### PR TITLE
enable to use "./mphash.so" in test

### DIFF
--- a/depend
+++ b/depend
@@ -57,4 +57,4 @@ clean-bin:
 
 .PHONY: test
 test:
-	$(RUBY) -Ilib test-all.rb
+	$(RUBY) -Ilib -I. test-all.rb


### PR DESCRIPTION
I guess the reason error happened when `make test` is security fix in ruby 1.9.
Now we need to add the current directory explicitly into $LOAD_PATH.
